### PR TITLE
feat: PicoClaw 国内镜像 fallback + AgentRegistry 自动注入 workspace md

### DIFF
--- a/docker-compose.infra.yml
+++ b/docker-compose.infra.yml
@@ -45,7 +45,7 @@ services:
     networks:
       - stock_network
     healthcheck:
-      test: ["CMD", "redis-cli", "-a", "${REDIS_PASSWORD:-Stock_datasource666}", "ping"]
+      test: ["CMD", "redis-cli", "-a", "${REDIS_PASSWORD:-your_redis_password_here}", "ping"]
       interval: 3s
       timeout: 10s
       retries: 10

--- a/skills/stock-data-assistant/generate_picoclaw_config.py
+++ b/skills/stock-data-assistant/generate_picoclaw_config.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-generate_picoclaw_config.py — 从项目 .env 生成 picoclaw 配置文件
+generate_picoclaw_config.py — 从项目 .env + AgentRegistry 生成 picoclaw 配置文件
 
 用法:
   python3 skills/stock-data-assistant/generate_picoclaw_config.py [选项]
@@ -10,12 +10,16 @@ generate_picoclaw_config.py — 从项目 .env 生成 picoclaw 配置文件
   --mcp-url URL     MCP 服务 URL (默认: 从环境变量或 http://localhost:8001/messages)
   --mcp-token TOKEN MCP 认证 token (默认: 从 STOCK_MCP_TOKEN 环境变量读取)
   --ws-url URL      实时数据 WebSocket 地址 (默认: ws://localhost:8765)
+  --workspace DIR   PicoClaw workspace 目录 (默认: ~/.picoclaw/workspace)
+  --no-workspace    不生成 workspace md 文件，仅生成 yaml 配置
   --help            显示帮助信息
 
 生成的配置包含:
   1. LLM 模型配置（复用项目的 OPENAI_API_KEY/BASE_URL/MODEL）
   2. MCP Server 连接（连接 stock_datasource 的 MCP 服务）
   3. 微信 Channel 配置
+  4. PicoClaw workspace md 文件（AGENTS.md / SOUL.md / TOOLS.md / USER.md / IDENTITY.md / HEARTBEAT.md）
+     — 自动从 AgentRegistry 读取 Agent 能力描述注入
 """
 
 import argparse
@@ -64,6 +68,320 @@ def detect_platform() -> str:
             return "darwin-aarch64"
     raise SystemExit(f"不支持的平台: {sys_name}-{machine}")
 
+
+# ---------------------------------------------------------------------------
+# Agent 能力收集（从 AgentRegistry 读取）
+# ---------------------------------------------------------------------------
+
+def collect_agent_capabilities() -> list[dict]:
+    """从 AgentRegistry 收集所有已注册 Agent 的能力描述。
+
+    Returns:
+        List of dicts with keys: name, description, markets, intents, tags
+    """
+    try:
+        # 延迟导入，避免循环依赖
+        from stock_datasource.services.agent_registrations import register_all_agents
+        from stock_datasource.services.agent_registry import get_agent_registry, AgentRole
+
+        register_all_agents()
+        registry = get_agent_registry()
+
+        agents = []
+        for desc in registry.list_descriptors(role=AgentRole.AGENT, enabled_only=True):
+            agents.append({
+                "name": desc.name,
+                "description": desc.description,
+                "markets": desc.capability.markets,
+                "intents": desc.capability.intents,
+                "tags": desc.capability.tags,
+                "priority": desc.priority,
+            })
+        return agents
+    except Exception as e:
+        print(f"[WARN] 无法从 AgentRegistry 获取能力描述: {e}", file=sys.stderr)
+        print("[WARN] 将使用默认 Agent 列表", file=sys.stderr)
+        return _fallback_agent_list()
+
+
+def _fallback_agent_list() -> list[dict]:
+    """当 AgentRegistry 不可用时的 fallback Agent 列表。"""
+    return [
+        {"name": "MarketAgent", "description": "A股和港股行情分析Agent，提供K线、技术指标、趋势分析等", "markets": ["A", "HK"], "intents": ["market_analysis", "hk_market_analysis"], "tags": ["market", "technical", "kline"], "priority": 10},
+        {"name": "ScreenerAgent", "description": "股票筛选Agent，支持多维度条件筛选", "markets": ["A"], "intents": ["stock_screening"], "tags": ["screener", "filter"], "priority": 5},
+        {"name": "ReportAgent", "description": "A股财务报表分析Agent", "markets": ["A"], "intents": ["financial_report"], "tags": ["report", "financial", "fundamental"], "priority": 8},
+        {"name": "HKReportAgent", "description": "港股财务报表分析Agent", "markets": ["HK"], "intents": ["hk_financial_report"], "tags": ["report", "financial", "hk"], "priority": 8},
+        {"name": "PortfolioAgent", "description": "投资组合管理Agent", "markets": [], "intents": ["portfolio_management"], "tags": ["portfolio"], "priority": 5},
+        {"name": "BacktestAgent", "description": "策略回测Agent", "markets": [], "intents": ["strategy_backtest"], "tags": ["backtest", "strategy"], "priority": 5},
+        {"name": "IndexAgent", "description": "指数分析Agent", "markets": [], "intents": ["index_analysis"], "tags": ["index"], "priority": 5},
+        {"name": "EtfAgent", "description": "ETF分析Agent", "markets": [], "intents": ["etf_analysis"], "tags": ["etf"], "priority": 5},
+        {"name": "OverviewAgent", "description": "市场概览Agent", "markets": [], "intents": ["market_overview"], "tags": ["overview", "market"], "priority": 3},
+        {"name": "TopListAgent", "description": "龙虎榜/排行Agent", "markets": [], "intents": ["toplist"], "tags": ["toplist", "ranking"], "priority": 3},
+        {"name": "NewsAnalystAgent", "description": "新闻分析Agent", "markets": [], "intents": ["news_analysis"], "tags": ["news"], "priority": 3},
+        {"name": "KnowledgeAgent", "description": "知识检索Agent(RAG)，用于研报、公告、政策文档查询", "markets": [], "intents": ["knowledge_search"], "tags": ["knowledge", "rag", "document"], "priority": 5},
+        {"name": "MemoryAgent", "description": "负责用户记忆管理，包括偏好设置、自选股管理等", "markets": [], "intents": ["memory_management"], "tags": ["memory", "preference", "watchlist"], "priority": 2},
+        {"name": "DataManageAgent", "description": "数据管理Agent，支持数据同步、状态查询等", "markets": [], "intents": ["data_management"], "tags": ["data", "management", "sync"], "priority": 2},
+        {"name": "ChatAgent", "description": "通用对话助手，处理一般性问答", "markets": [], "intents": ["general_chat"], "tags": ["chat", "general"], "priority": 0},
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Workspace md 文件生成
+# ---------------------------------------------------------------------------
+
+def generate_agents_md(agents: list[dict]) -> str:
+    """生成 AGENTS.md — Agent 行为指南（最高优先级）。
+
+    这是 PicoClaw workspace 中最重要的文件，定义了：
+    - 系统整体能力范围
+    - 所有可用 Agent 及其职责
+    - 用户请求路由规则
+    - MCP 工具使用指南
+    """
+    agent_lines = []
+    for a in sorted(agents, key=lambda x: -x["priority"]):
+        markets = ", ".join(a["markets"]) if a["markets"] else "通用"
+        intents = ", ".join(a["intents"]) if a["intents"] else ""
+        agent_lines.append(
+            f"### {a['name']}\n"
+            f"- **描述**: {a['description']}\n"
+            f"- **市场**: {markets}\n"
+            f"- **能力标签**: {', '.join(a['tags']) if a['tags'] else '无'}\n"
+        )
+
+    agents_section = "\n".join(agent_lines)
+
+    return f"""# Stock Datasource — Agent 行为指南
+
+你是 **Stock Datasource** 智能股票分析平台的 AI 助手。本文件定义你的行为规范和能力边界。
+
+## 系统概述
+
+Stock Datasource 是一个专业的股票数据分析平台，提供以下核心能力：
+- A股/港股行情查询与技术分析
+- 财务报表分析与基本面研究
+- 智能选股与筛选
+- 策略回测
+- 投资组合管理
+- 实时行情推送（WebSocket）
+- 研报/公告/政策文档检索（RAG）
+- 市场新闻分析
+
+## 可用 Agent 列表
+
+{agents_section}
+
+## 请求路由规则
+
+1. **行情分析**（K线、技术指标、趋势） → MarketAgent
+2. **A股财务分析**（财报、盈利、基本面） → ReportAgent
+3. **港股财务分析** → HKReportAgent
+4. **选股/筛选** → ScreenerAgent
+5. **策略回测** → BacktestAgent
+6. **投资组合** → PortfolioAgent
+7. **指数分析** → IndexAgent
+8. **ETF 分析** → EtfAgent
+9. **市场概览** → OverviewAgent
+10. **龙虎榜/排行** → TopListAgent
+11. **新闻分析** → NewsAnalystAgent
+12. **研报/公告/文档** → KnowledgeAgent
+13. **自选股/偏好管理** → MemoryAgent
+14. **数据同步/管理** → DataManageAgent
+15. **一般对话** → ChatAgent
+
+## MCP 工具使用
+
+你通过 MCP Server 连接 Stock Datasource 的 76+ 数据查询工具。使用时注意：
+- 优先使用 MCP 工具获取数据，不要凭记忆回答行情数据
+- A股代码格式：`600519.SH`；港股代码格式：`00700.HK`
+- 技术分析请求应明确指定周期（日K/周K/月K）
+- 财务分析请求优先使用最新财报数据
+
+## 安全边界
+
+- **绝不**提供投资建议或推荐买卖某只股票
+- **绝不**保证任何收益或预测股价涨跌
+- 分析基于历史数据，提示用户注意风险
+- 涉及港股时，提示汇率和交易规则差异
+"""
+
+
+def generate_soul_md() -> str:
+    """生成 SOUL.md — Agent 灵魂设定（人格与行为风格）。"""
+    return """# Stock Datasource — 灵魂设定
+
+## 性格
+
+你是一位专业、严谨、耐心的股票数据分析助手。你的核心特质：
+
+- **专业**: 使用准确的金融术语，数据分析有据可查
+- **严谨**: 对不确定的信息标注来源和时效，不编造数据
+- **耐心**: 用清晰易懂的方式解释复杂概念
+- **中立**: 不偏向任何投资标的，客观呈现事实
+
+## 沟通风格
+
+- 回复使用中文，专业术语保留英文原文
+- 数据引用标注来源和更新时间
+- 复杂分析先给结论，再展开细节
+- 适当使用表格整理对比数据
+- 遇到模糊问题主动澄清意图
+
+## 决策原则
+
+1. 数据准确性 > 回复速度
+2. 客观事实 > 主观判断
+3. 风险提示 > 收益描述
+4. 历史依据 > 预测推断
+"""
+
+
+def generate_tools_md(mcp_url: str, ws_url: str, mcp_token: str | None) -> str:
+    """生成 TOOLS.md — 工具说明（本地环境配置）。"""
+    auth_line = f'Authorization: "Bearer {mcp_token}"' if mcp_token else "# 设置 MCP token 后启用认证"
+
+    return f"""# Stock Datasource — 工具配置
+
+## MCP Server
+
+- **名称**: stock-data
+- **类型**: streamable-http
+- **URL**: {mcp_url}
+- **认证**: {auth_line}
+- **工具数量**: 76+
+
+### 常用 MCP 工具分类
+
+| 类别 | 工具示例 | 说明 |
+|------|---------|------|
+| 行情查询 | query_stock_daily, query_stock_kline | 日K/周K/月K数据 |
+| 财务分析 | query_financial_report, query_balance_sheet | 财报/资产负债表 |
+| 选股筛选 | screen_stocks, screen_by_indicator | 多维度条件筛选 |
+| 指数数据 | query_index_daily, query_index_components | 指数行情/成分股 |
+| ETF 数据 | query_etf_daily, query_etf_holdings | ETF 行情/持仓 |
+| 港股数据 | query_hk_daily, query_hk_financial | 港股行情/财报 |
+| 新闻研报 | search_knowledge, query_announcements | 研报/公告检索 |
+
+## 实时数据
+
+- **WebSocket**: {ws_url}
+- **默认订阅**: 00700.HK, 09988.HK, 600519.SH
+- **数据类型**: 逐笔成交、分钟K线、盘口快照
+
+## 微信 Channel
+
+- **类型**: weixin
+- **状态**: 已启用
+- **登录**: `picoclaw auth weixin`
+"""
+
+
+def generate_user_md() -> str:
+    """生成 USER.md — 用户偏好。"""
+    return """# Stock Datasource — 用户偏好
+
+## 基本信息
+
+- **语言**: 中文
+- **时区**: Asia/Shanghai (UTC+8)
+- **交易时间**: A股 09:30-15:00, 港股 09:30-16:00
+
+## 沟通偏好
+
+- 回复使用中文
+- 数据展示优先使用表格
+- 金额单位默认人民币（CNY），港股标注港币（HKD）
+- 价格默认保留2位小数，百分比保留2位
+
+## 关注市场
+
+- A股（上海/深圳）
+- 港股（港股通标的）
+
+## 数据偏好
+
+- 优先使用最新数据
+- 技术指标默认日K周期
+- 财务数据使用最近一期报告
+"""
+
+
+def generate_identity_md() -> str:
+    """生成 IDENTITY.md — Agent 身份设定。"""
+    return """# Stock Datasource — 身份设定
+
+- **名称**: Stock Datasource 助手
+- **类型**: 专业股票数据分析 AI
+- **版本**: 1.0
+- **创建者**: Stock Datasource Platform
+
+你是 Stock Datasource 平台的智能助手，专注于为用户提供准确、专业的股票数据分析服务。你不是一个通用聊天机器人——你是金融数据分析专家。
+"""
+
+
+def generate_heartbeat_md() -> str:
+    """生成 HEARTBEAT.md — 周期任务提示。"""
+    return """# Stock Datasource — 周期任务
+
+## 定时检查项（每30分钟）
+
+- [ ] 检查是否有新的用户消息需要处理
+- [ ] 如果用户关注了特定股票，可以主动推送重要行情变化（涨跌幅超5%）
+- [ ] 盘中时段（09:30-15:00）检查实时数据连接状态
+
+## 注意事项
+
+- 非交易时段不推送行情提醒
+- 不主动发送消息打扰用户，除非有重要变化
+- 每日收盘后可提供当日市场总结（如果用户订阅）
+"""
+
+
+def write_workspace_files(workspace_dir: Path, agents: list[dict],
+                          mcp_url: str, ws_url: str, mcp_token: str | None) -> None:
+    """将所有 workspace md 文件写入 PicoClaw 的 ~/.picoclaw/workspace/ 目录。
+
+    PicoClaw workspace 目录结构:
+      ~/.picoclaw/workspace/
+      ├── AGENTS.md          # Agent 行为指南（最高优先级，每次会话加载）
+      ├── SOUL.md            # 灵魂设定（性格与风格，每次会话加载）
+      ├── IDENTITY.md        # 身份设定（名称与角色）
+      ├── USER.md            # 用户偏好（沟通方式、市场偏好）
+      ├── TOOLS.md           # 工具说明（MCP配置、数据源）
+      ├── HEARTBEAT.md       # 周期任务提示（每30分钟检查）
+      ├── memory/            # 长期记忆目录
+      ├── sessions/          # 对话历史
+      ├── state/             # 运行状态
+      ├── cron/              # 定时任务
+      └── skills/            # 自定义技能
+    """
+    workspace_dir.mkdir(parents=True, exist_ok=True)
+
+    # 创建子目录
+    for subdir in ("memory", "sessions", "state", "cron", "skills"):
+        (workspace_dir / subdir).mkdir(exist_ok=True)
+
+    # 写入 md 文件
+    files = {
+        "AGENTS.md": generate_agents_md(agents),
+        "SOUL.md": generate_soul_md(),
+        "IDENTITY.md": generate_identity_md(),
+        "USER.md": generate_user_md(),
+        "TOOLS.md": generate_tools_md(mcp_url, ws_url, mcp_token),
+        "HEARTBEAT.md": generate_heartbeat_md(),
+    }
+
+    for filename, content in files.items():
+        path = workspace_dir / filename
+        path.write_text(content, encoding="utf-8")
+        print(f"  [OK] {path}")
+
+    print(f"\n[OK] Workspace 文件已写入 {workspace_dir}")
+
+
+# ---------------------------------------------------------------------------
+# YAML 配置生成
+# ---------------------------------------------------------------------------
 
 def generate_config(
     env: dict[str, str],
@@ -125,14 +443,23 @@ realtime_data:
 
 def main():
     parser = argparse.ArgumentParser(
-        description="从项目 .env 生成 picoclaw 配置",
+        description="从项目 .env + AgentRegistry 生成 picoclaw 配置及 workspace 文件",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 示例:
   python3 generate_picoclaw_config.py
   python3 generate_picoclaw_config.py --output ./my-picoclaw.yaml
   python3 generate_picoclaw_config.py --mcp-token sk-xxx123
+  python3 generate_picoclaw_config.py --no-workspace
   STOCK_MCP_TOKEN=sk-xxx python3 generate_picoclaw_config.py
+
+PicoClaw workspace md 文件说明:
+  AGENTS.md      — Agent 行为指南 + 能力路由（最高优先级，每次会话加载）
+  SOUL.md        — 灵魂设定（性格与沟通风格）
+  IDENTITY.md    — 身份设定（名称与角色定义）
+  USER.md        — 用户偏好（语言、市场、数据习惯）
+  TOOLS.md       — 工具说明（MCP Server、WebSocket 配置）
+  HEARTBEAT.md   — 周期任务提示（每30分钟检查一次）
 """,
     )
     parser.add_argument(
@@ -158,6 +485,16 @@ def main():
         default="ws://localhost:8765",
         help="实时数据 WebSocket 地址",
     )
+    parser.add_argument(
+        "--workspace",
+        default=None,
+        help="PicoClaw workspace 目录 (默认: ~/.picoclaw/workspace)",
+    )
+    parser.add_argument(
+        "--no-workspace",
+        action="store_true",
+        help="不生成 workspace md 文件，仅生成 yaml 配置",
+    )
     args = parser.parse_args()
 
     # 加载 .env
@@ -168,7 +505,7 @@ def main():
     output_path = Path(args.output) if args.output else default_output
     output_path.parent.mkdir(parents=True, exist_ok=True)
 
-    # 生成配置
+    # 生成 yaml 配置
     yaml_content = generate_config(
         env=env,
         mcp_url=args.mcp_url,
@@ -183,6 +520,28 @@ def main():
 
     if not args.mcp_token and not os.environ.get("STOCK_MCP_TOKEN"):
         print("[WARN] 未设置 MCP token，请在生成的配置文件中填入有效的认证令牌")
+
+    # 生成 workspace md 文件
+    if not args.no_workspace:
+        # 收集 Agent 能力
+        print("\n--- 收集 Agent 能力描述 ---")
+        agents = collect_agent_capabilities()
+        print(f"[OK] 发现 {len(agents)} 个已注册 Agent")
+
+        # 确定 workspace 目录
+        workspace_dir = (
+            Path(args.workspace) if args.workspace
+            else Path.home() / ".picoclaw" / "workspace"
+        )
+
+        print(f"\n--- 生成 PicoClaw Workspace 文件 ---")
+        write_workspace_files(
+            workspace_dir=workspace_dir,
+            agents=agents,
+            mcp_url=args.mcp_url,
+            ws_url=args.ws_url,
+            mcp_token=args.mcp_token or None,
+        )
 
 
 if __name__ == "__main__":

--- a/skills/stock-data-assistant/references/picoclaw_config_example.yaml
+++ b/skills/stock-data-assistant/references/picoclaw_config_example.yaml
@@ -7,9 +7,9 @@
 # --- LLM 模型列表 ---
 # 支持多个模型，第一个作为默认模型
 model_list:
-  - model: "Kimi-K2-Thinking"
-    base_url: "https://api.haihub.cn/v1/"
-    api_key: "sk-d2d0dc36-f065-46ed-a897-0ddcbd0046eb"
+  - model: "your_model_name"
+    base_url: "https://api.example.com/v1/"
+    api_key: "your_api_key_here"
     model_type: "openai-chat"
   # 可选：添加备用模型
   # - model: "gpt-4o-mini"
@@ -49,9 +49,48 @@ realtime_data:
     - "09988.HK"    # 阿里巴巴
     - "600519.SH"   # 贵州茅台
 
-# --- Agent 系统提示词增强（可选） ---
-# system_prompt: |
-#   你是一个专业的股票数据分析助手。
-#   用户可以通过微信向你提问股票相关问题。
-#   你可以使用 MCP 工具查询历史数据，使用实时数据接口获取最新行情。
-#   请用简洁清晰的语言回答问题。
+# ============================================
+# Workspace md 文件说明（自动注入到 ~/.picoclaw/workspace/）
+# ============================================
+# generate_picoclaw_config.py 会自动将以下文件写入 PicoClaw 的 workspace 目录。
+# 这些 md 文件构成 PicoClaw 的"自我认知"，决定了它如何理解自身能力。
+#
+# ~/.picoclaw/workspace/
+# ├── AGENTS.md          # Agent 行为指南 — 最高优先级，每次会话加载
+# │                        定义系统能力范围、所有 Agent 职责、路由规则、安全边界
+# │                        [注入内容] AgentRegistry 中 16 个 Agent 的描述+路由规则
+# │
+# ├── SOUL.md            # 灵魂设定 — 性格与沟通风格
+# │                        定义 Agent 的个性、决策原则
+# │                        [注入内容] 专业/严谨/中立的金融分析师人格
+# │
+# ├── IDENTITY.md        # 身份设定 — Agent 名称与角色定义
+# │                        告诉 PicoClaw "我是谁"
+# │                        [注入内容] Stock Datasource 助手身份
+# │
+# ├── USER.md            # 用户偏好 — 语言、市场、数据习惯
+# │                        让 Agent 了解服务对象的偏好
+# │                        [注入内容] 中文、Asia/Shanghai、A股+港股
+# │
+# ├── TOOLS.md           # 工具说明 — MCP Server、WebSocket 配置
+# │                        描述可用工具的配置和分类
+# │                        [注入内容] MCP 76+ 工具分类、实时数据配置
+# │
+# ├── HEARTBEAT.md       # 周期任务提示 — 每 30 分钟检查
+# │                        定义 Agent 的主动行为
+# │                        [注入内容] 行情提醒、连接检查
+# │
+# ├── memory/            # 长期记忆（自动管理）
+# ├── sessions/          # 对话历史（自动管理）
+# ├── state/             # 运行状态（自动管理）
+# ├── cron/              # 定时任务（自动管理）
+# └── skills/            # 自定义技能（可选扩展）
+#
+# 不同 md 文件的注入策略：
+#   AGENTS.md    → 动态注入：从 AgentRegistry 读取最新 Agent 列表
+#   SOUL.md      → 静态模板：金融分析师人格定义
+#   IDENTITY.md  → 静态模板：系统身份定义
+#   USER.md      → 静态模板：默认用户偏好（用户可自行修改）
+#   TOOLS.md     → 动态注入：根据 MCP/WS 配置生成
+#   HEARTBEAT.md → 静态模板：周期任务定义
+# ============================================

--- a/skills/stock-data-assistant/setup_picoclaw.sh
+++ b/skills/stock-data-assistant/setup_picoclaw.sh
@@ -3,6 +3,11 @@
 # setup_picoclaw.sh — 自动下载/更新 picoclaw 二进制文件
 # 用法: bash skills/stock-data-assistant/setup_picoclaw.sh [version]
 #   version: 可选，如 "v0.2.5"，默认下载最新版
+#
+# 国内镜像支持:
+#   默认按顺序尝试: ghfast.top -> ghproxy.cc -> GitHub 直连
+#   可通过 PICOCLAW_MIRROR 环境变量指定镜像前缀:
+#     PICOCLAW_MIRROR="https://ghfast.top" bash setup_picoclaw.sh
 # ============================================================
 
 set -euo pipefail
@@ -11,6 +16,14 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 BIN_DIR="$PROJECT_ROOT/.local/bin"
 BINARY_NAME="picoclaw"
+
+# 国内镜像列表（按优先级排列）
+DEFAULT_MIRRORS=(
+    "https://ghfast.top"
+    "https://ghproxy.cc"
+    "DIRECT"  # GitHub 直连
+)
+GITHUB_BASE="https://github.com"
 
 # 颜色输出
 RED='\033[0;31m'
@@ -38,23 +51,79 @@ detect_arch() {
     echo "$arch"
 }
 
-# 获取最新 release 版本
+# 获取最新 release 版本（支持镜像 fallback）
 get_latest_version() {
     local version
-    version=$(curl -sfL https://api.github.com/repos/sipeed/picoclaw/releases/latest \
+
+    # 尝试 GitHub API（可能需要镜像）
+    local api_url="https://api.github.com/repos/sipeed/picoclaw/releases/latest"
+
+    # 先试直连
+    version=$(curl -sfL --max-time 10 "$api_url" 2>/dev/null \
         | grep '"tag_name"' \
-        | sed -E 's/.*"tag_name":\s*"([^"]+)".*/\1/')
+        | sed -E 's/.*"tag_name":\s*"([^"]+)".*/\1/' || true)
+
+    # 直连失败则用镜像代理 API
+    if [[ -z "$version" ]]; then
+        log_warn "GitHub API 直连失败，尝试镜像..."
+        for mirror in "${DEFAULT_MIRRORS[@]}"; do
+            [[ "$mirror" == "DIRECT" ]] && continue
+            local mirrored_api="${mirror}/${api_url}"
+            version=$(curl -sfL --max-time 15 "$mirrored_api" 2>/dev/null \
+                | grep '"tag_name"' \
+                | sed -E 's/.*"tag_name":\s*"([^"]+)".*/\1/' || true)
+            if [[ -n "$version" ]]; then
+                log_info "通过镜像 $mirror 获取版本成功"
+                break
+            fi
+        done
+    fi
+
     if [[ -z "$version" ]]; then
         log_error "无法获取 picoclaw 最新版本，请检查网络连接"
+        log_error "也可指定版本号: bash setup_picoclaw.sh v0.2.6"
         exit 1
     fi
     echo "$version"
 }
 
+# 尝试通过多个镜像下载
+download_with_mirrors() {
+    local github_path="$1"  # e.g. /sipeed/picoclaw/releases/download/v0.2.6/picoclaw-linux-x86_64
+    local output_file="$2"
+
+    # 如果用户指定了镜像，优先使用
+    local mirrors=()
+    if [[ -n "${PICOCLAW_MIRROR:-}" ]]; then
+        mirrors=("$PICOCLAW_MIRROR" "DIRECT")
+    else
+        mirrors=("${DEFAULT_MIRRORS[@]}")
+    fi
+
+    for mirror in "${mirrors[@]}"; do
+        local url
+        if [[ "$mirror" == "DIRECT" ]]; then
+            url="${GITHUB_BASE}${github_path}"
+            log_info "尝试 GitHub 直连: $url"
+        else
+            url="${mirror}/${GITHUB_BASE}${github_path}"
+            log_info "尝试镜像 $mirror: $url"
+        fi
+
+        if curl -fSL --max-time 120 --progress-bar -o "$output_file" "$url" 2>/dev/null; then
+            log_info "下载成功 (via ${mirror})"
+            return 0
+        fi
+        log_warn "下载失败 (${mirror})，尝试下一个源..."
+    done
+
+    return 1
+}
+
 # 主流程
 main() {
     local TARGET_VERSION="${1:-}"
-    local ARCH VERSION DOWNLOAD_URL
+    local ARCH VERSION
 
     # 检测架构
     ARCH=$(detect_arch)
@@ -62,7 +131,6 @@ main() {
 
     # 确定版本
     if [[ -n "$TARGET_VERSION" ]]; then
-        # 用户指定了版本，去掉 v 前缀（如果有）
         VERSION="$TARGET_VERSION"
         [[ ! "$VERSION" =~ ^v ]] && VERSION="v$VERSION"
     else
@@ -73,7 +141,7 @@ main() {
     # 创建 bin 目录
     mkdir -p "$BIN_DIR"
 
-    # 构建下载 URL（picoclaw release 格式：picoclaw-{os}-{arch})
+    # 构建下载路径（picoclaw release 格式：picoclaw-{os}-{arch})
     local os_part arch_part
     case "$ARCH" in
         linux-amd64)    os_part="linux"; arch_part="x86_64" ;;
@@ -81,22 +149,22 @@ main() {
         linux-riscv64)  os_part="linux"; arch_part="riscv64" ;;
     esac
 
-    # picoclaw 的 release 文件名格式: picoclaw-linux-x86_64 等
     local FILENAME="picoclaw-${os_part}-${arch_part}"
-    DOWNLOAD_URL="https://github.com/sipeed/picoclaw/releases/download/${VERSION}/${FILENAME}"
+    local GITHUB_PATH="/sipeed/picoclaw/releases/download/${VERSION}/${FILENAME}"
 
-    log_info "下载地址: $DOWNLOAD_URL"
     log_info "目标路径: $BIN_DIR/$BINARY_NAME"
 
-    # 下载
+    # 下载（带镜像 fallback）
     TMPFILE=$(mktemp)
     trap 'rm -f "$TMPFILE"' EXIT
 
     log_info "正在下载 picoclaw ${VERSION} ..."
-    if ! curl -fSL --progress-bar -o "$TMPFILE" "$DOWNLOAD_URL"; then
+    if ! download_with_mirrors "$GITHUB_PATH" "$TMPFILE"; then
         rm -f "$TMPFILE"
-        log_error "下载失败！请手动检查: $DOWNLOAD_URL"
-        log_error "可能需要从 GitHub Releases 页面确认正确的文件名"
+        log_error "所有下载源均失败！"
+        log_error "请手动从以下地址下载:"
+        log_error "  GitHub: https://github.com/sipeed/picoclaw/releases"
+        log_error "  镜像:   https://ghfast.top/https://github.com/sipeed/picoclaw/releases"
         exit 1
     fi
 

--- a/src/stock_datasource/modules/wechat_bridge/service.py
+++ b/src/stock_datasource/modules/wechat_bridge/service.py
@@ -28,6 +28,13 @@ LOG_FILE = LOCAL_DIR / "picoclaw.log"
 # GitHub release info
 PICOCLAW_GITHUB_REPO = "sipeed/picoclaw"
 
+# 国内镜像列表（按优先级排列，DIRECT 表示 GitHub 直连）
+_DEFAULT_MIRRORS = [
+    "https://ghfast.top",
+    "https://ghproxy.cc",
+    "DIRECT",
+]
+
 
 def _detect_arch() -> tuple[str, str]:
     """Detect system architecture for binary download.
@@ -65,9 +72,15 @@ def _detect_arch() -> tuple[str, str]:
 
 
 def _get_latest_version() -> str:
-    """Query GitHub API for latest picoclaw release tag."""
-    url = f"https://api.github.com/repos/{PICOCLAW_GITHUB_REPO}/releases/latest"
-    req = urllib.request.Request(url, headers={
+    """Query GitHub API for latest picoclaw release tag.
+
+    Tries GitHub API directly first, then falls back to mirror proxies
+    for users in China where api.github.com may be blocked.
+    """
+    api_url = f"https://api.github.com/repos/{PICOCLAW_GITHUB_REPO}/releases/latest"
+
+    # Try direct connection first
+    req = urllib.request.Request(api_url, headers={
         "User-Agent": "stock-datasource",
         "Accept": "application/vnd.github+json",
     })
@@ -75,19 +88,76 @@ def _get_latest_version() -> str:
         with urllib.request.urlopen(req, timeout=15) as resp:
             data = json.loads(resp.read().decode())
         tag = data.get("tag_name")
-        if not tag:
-            raise RuntimeError("No tag_name in GitHub release response")
-        return tag
+        if tag:
+            return tag
     except Exception as e:
-        # Fallback to a known good version
-        logger.warning(f"Failed to fetch latest version from GitHub API ({e}), falling back to v0.2.5")
-        return "v0.2.5"
+        logger.warning(f"GitHub API direct failed ({e}), trying mirrors...")
+
+    # Fallback to mirror proxies for GitHub API
+    for mirror in _DEFAULT_MIRRORS:
+        if mirror == "DIRECT":
+            continue
+        mirrored_url = f"{mirror}/{api_url}"
+        try:
+            req = urllib.request.Request(mirrored_url, headers={"User-Agent": "stock-datasource"})
+            with urllib.request.urlopen(req, timeout=15) as resp:
+                data = json.loads(resp.read().decode())
+            tag = data.get("tag_name")
+            if tag:
+                logger.info(f"Got version via mirror {mirror}: {tag}")
+                return tag
+        except Exception:
+            continue
+
+    # Last resort: known good version
+    logger.warning("All GitHub API sources failed, falling back to v0.2.6")
+    return "v0.2.6"
+
+
+def _download_with_mirrors(github_path: str, dest_path: str) -> None:
+    """Download a file from GitHub with mirror fallback for China users.
+
+    Tries each mirror in order.  The PICOCLAW_MIRROR env var can be set
+    to force a specific mirror prefix (e.g. "https://ghfast.top").
+    """
+    mirrors = list(_DEFAULT_MIRRORS)
+    custom = os.environ.get("PICOCLAW_MIRROR")
+    if custom:
+        mirrors = [custom, "DIRECT"]
+
+    github_base = "https://github.com"
+    errors: list[str] = []
+
+    for mirror in mirrors:
+        if mirror == "DIRECT":
+            url = f"{github_base}{github_path}"
+        else:
+            url = f"{mirror}/{github_base}{github_path}"
+
+        logger.info(f"Trying download: {url}")
+        try:
+            req = urllib.request.Request(url, headers={"User-Agent": "stock-datasource"})
+            with urllib.request.urlopen(req, timeout=180) as resp:
+                with open(dest_path, "wb") as f:
+                    shutil.copyfileobj(resp, f)
+            logger.info(f"Download succeeded via {mirror}")
+            return
+        except Exception as e:
+            errors.append(f"{mirror}: {e}")
+            logger.warning(f"Download failed via {mirror}: {e}")
+            continue
+
+    raise RuntimeError(
+        f"All download sources failed for {github_path}. Errors:\n"
+        + "\n".join(f"  - {e}" for e in errors)
+    )
 
 
 def _download_picoclaw(version: Optional[str] = None) -> str:
     """Download picoclaw binary from GitHub releases and install to BIN_DIR.
-    
-    The release asset is a .tar.gz archive containing the 'picoclaw' binary.
+
+    Uses mirror proxies (ghfast.top, ghproxy.cc) as fallback when GitHub
+    is not directly accessible (common in mainland China).
     Returns version string of installed binary.
     """
     # Detect architecture
@@ -99,29 +169,24 @@ def _download_picoclaw(version: Optional[str] = None) -> str:
     elif not version.startswith("v"):
         version = f"v{version}"
 
-    # Build download URL — matches GoReleaser output format:
-    #   https://github.com/sipeed/picoclaw/releases/download/v0.2.5/picoclaw_Linux_x86_64.tar.gz
+    # Build download path — matches GoReleaser output format:
+    #   /sipeed/picoclaw/releases/download/v0.2.5/picoclaw_Linux_x86_64.tar.gz
     filename = f"picoclaw_{os_part}_{arch_part}.tar.gz"
-    download_url = (
-        f"https://github.com/{PICOCLAW_GITHUB_REPO}"
+    github_path = (
+        f"/{PICOCLAW_GITHUB_REPO}"
         f"/releases/download/{version}/{filename}"
     )
 
-    logger.info(f"Downloading picoclaw {version} ({os_part}-{arch_part}) -> {download_url}")
+    logger.info(f"Downloading picoclaw {version} ({os_part}-{arch_part})")
 
-    # Download tar.gz to temp file
+    # Download tar.gz to temp file (with mirror fallback)
     tmp_fd, tmp_path = tempfile.mkstemp(suffix=".tar.gz", prefix="picoclaw_")
     try:
-        req = urllib.request.Request(download_url, headers={"User-Agent": "stock-datasource"})
-        with urllib.request.urlopen(req, timeout=180) as resp:
-            with os.fdopen(tmp_fd, "wb") as f:
-                shutil.copyfileobj(resp, f)
+        os.close(tmp_fd)  # _download_with_mirrors opens its own file handle
+        _download_with_mirrors(github_path, tmp_path)
     except Exception:
         os.unlink(tmp_path)
-        raise RuntimeError(
-            f"Failed to download picoclaw from {download_url}. "
-            f"Check network connectivity and verify URL."
-        )
+        raise
 
     # Extract tar.gz and install binary
     BIN_DIR.mkdir(parents=True, exist_ok=True)
@@ -295,6 +360,9 @@ def generate_config(mcp_token: Optional[str] = None) -> dict:
     PICOCLAW_CONFIG.write_text(json.dumps(cfg, indent=2, ensure_ascii=False), encoding="utf-8")
     logger.info(f"Config written to {PICOCLAW_CONFIG}")
 
+    # Auto-inject workspace md files (AGENTS.md, SOUL.md, etc.)
+    _inject_workspace_md(token)
+
     return {
         "llm_model": model,
         "llm_base_url": base_url,
@@ -303,6 +371,194 @@ def generate_config(mcp_token: Optional[str] = None) -> dict:
         "channel_weixin_enabled": True,
         "config_path": str(PICOCLAW_CONFIG),
     }
+
+
+PICOCLAW_WORKSPACE = Path.home() / ".picoclaw" / "workspace"
+
+
+def _inject_workspace_md(mcp_token: Optional[str] = None) -> dict:
+    """Inject workspace md files into PicoClaw's ~/.picoclaw/workspace/.
+
+    This ensures PicoClaw has full knowledge of stock_datasource's
+    agent capabilities, personality, and tool configuration.
+
+    Each md file serves a distinct purpose:
+      AGENTS.md     — Agent behavior guide + capability routing (highest priority)
+      SOUL.md       — Personality and communication style
+      IDENTITY.md   — Agent name and role definition
+      USER.md       — User preferences (language, markets, data habits)
+      TOOLS.md      — MCP / WebSocket tool descriptions
+      HEARTBEAT.md  — Periodic task prompts (checked every 30 min)
+    """
+    try:
+        from stock_datasource.services.agent_registrations import register_all_agents
+        from stock_datasource.services.agent_registry import get_agent_registry, AgentRole
+
+        register_all_agents()
+        registry = get_agent_registry()
+
+        agents = []
+        for desc in registry.list_descriptors(role=AgentRole.AGENT, enabled_only=True):
+            agents.append({
+                "name": desc.name,
+                "description": desc.description,
+                "markets": desc.capability.markets,
+                "intents": desc.capability.intents,
+                "tags": desc.capability.tags,
+                "priority": desc.priority,
+            })
+    except Exception as e:
+        logger.warning(f"Failed to collect agent capabilities from registry: {e}")
+        agents = []
+
+    PICOCLAW_WORKSPACE.mkdir(parents=True, exist_ok=True)
+    for subdir in ("memory", "sessions", "state", "cron", "skills"):
+        (PICOCLAW_WORKSPACE / subdir).mkdir(exist_ok=True)
+
+    mcp_url = "http://localhost:8001/messages"
+    ws_url = "ws://localhost:8765"
+
+    # Generate and write each md file
+    files_to_write = {
+        "AGENTS.md": _build_agents_md(agents),
+        "SOUL.md": _build_soul_md(),
+        "IDENTITY.md": _build_identity_md(),
+        "USER.md": _build_user_md(),
+        "TOOLS.md": _build_tools_md(mcp_url, ws_url, mcp_token),
+        "HEARTBEAT.md": _build_heartbeat_md(),
+    }
+
+    written = []
+    for filename, content in files_to_write.items():
+        path = PICOCLAW_WORKSPACE / filename
+        path.write_text(content, encoding="utf-8")
+        written.append(filename)
+
+    logger.info(f"Injected {len(written)} workspace md files to {PICOCLAW_WORKSPACE}: {', '.join(written)}")
+    return {"workspace_dir": str(PICOCLAW_WORKSPACE), "files": written}
+
+
+def _build_agents_md(agents: list[dict]) -> str:
+    """Build AGENTS.md — Agent behavior guide (highest priority)."""
+    if not agents:
+        agent_section = "- MarketAgent: A股和港股行情分析 (市场: A, HK)\n- ChatAgent: 通用对话助手 (市场: 通用)"
+    else:
+        lines = []
+        for a in sorted(agents, key=lambda x: -x["priority"]):
+            markets = ", ".join(a["markets"]) if a["markets"] else "通用"
+            lines.append(f"- **{a['name']}**: {a['description']} (市场: {markets})")
+        agent_section = "\n".join(lines)
+
+    return f"""# Stock Datasource — Agent 行为指南
+
+你是 **Stock Datasource** 智能股票分析平台的 AI 助手。
+
+## 可用 Agent
+
+{agent_section}
+
+## 路由规则
+
+1. 行情/K线/技术分析 → MarketAgent
+2. A股财报/基本面 → ReportAgent
+3. 港股财报 → HKReportAgent
+4. 选股筛选 → ScreenerAgent
+5. 策略回测 → BacktestAgent
+6. 投资组合 → PortfolioAgent
+7. 指数分析 → IndexAgent
+8. ETF分析 → EtfAgent
+9. 市场概览 → OverviewAgent
+10. 龙虎榜 → TopListAgent
+11. 新闻 → NewsAnalystAgent
+12. 研报/公告 → KnowledgeAgent
+13. 自选股/偏好 → MemoryAgent
+14. 数据管理 → DataManageAgent
+15. 一般对话 → ChatAgent
+
+## MCP 工具
+
+通过 MCP Server 连接 76+ 数据查询工具。优先使用 MCP 获取数据。
+A股代码: 600519.SH | 港股代码: 00700.HK
+
+## 安全边界
+
+- 不提供投资建议
+- 不预测股价涨跌
+- 历史数据不代表未来表现
+"""
+
+
+def _build_soul_md() -> str:
+    return """# Stock Datasource — 灵魂设定
+
+## 性格
+专业、严谨、耐心的股票数据分析助手。
+
+## 沟通风格
+- 中文回复，专业术语保留英文
+- 数据标注来源和时效
+- 先结论后细节
+- 表格整理对比数据
+- 模糊问题主动澄清
+
+## 决策原则
+1. 数据准确 > 回复速度
+2. 客观事实 > 主观判断
+3. 风险提示 > 收益描述
+"""
+
+
+def _build_identity_md() -> str:
+    return """# Stock Datasource — 身份设定
+
+- **名称**: Stock Datasource 助手
+- **类型**: 专业股票数据分析 AI
+- **版本**: 1.0
+"""
+
+
+def _build_user_md() -> str:
+    return """# Stock Datasource — 用户偏好
+
+- **语言**: 中文
+- **时区**: Asia/Shanghai (UTC+8)
+- **A股交易时间**: 09:30-15:00
+- **港股交易时间**: 09:30-16:00
+- **金额单位**: 人民币(CNY)，港股标注港币(HKD)
+"""
+
+
+def _build_tools_md(mcp_url: str, ws_url: str, mcp_token: Optional[str]) -> str:
+    auth = f"Bearer {mcp_token}" if mcp_token else "未设置"
+    return f"""# Stock Datasource — 工具配置
+
+## MCP Server
+- URL: {mcp_url}
+- 认证: {auth}
+- 工具数: 76+
+
+## 实时数据
+- WebSocket: {ws_url}
+- 默认订阅: 00700.HK, 09988.HK, 600519.SH
+
+## 微信 Channel
+- 类型: weixin
+- 状态: 已启用
+"""
+
+
+def _build_heartbeat_md() -> str:
+    return """# Stock Datasource — 周期任务
+
+## 每30分钟检查
+- 检查新用户消息
+- 关注股票涨跌幅超5%时推送提醒
+- 盘中检查实时数据连接
+
+## 注意
+- 非交易时段不推送行情
+- 不主动打扰用户
+"""
 
 
 def start_bridge(symbols: Optional[str] = None, no_rt: bool = False) -> dict:


### PR DESCRIPTION
1. PicoClaw 下载增加国内镜像 fallback (ghfast.top/ghproxy.cc)
   - setup_picoclaw.sh: 多镜像源下载 + PICOCLAW_MIRROR 环境变量
   - service.py: _download_with_mirrors() + _get_latest_version() 镜像支持

2. generate_picoclaw_config.py 自动从 AgentRegistry 读取能力描述
   - collect_agent_capabilities() 动态读取 16 个 Agent 描述
   - write_workspace_files() 生成 6 个 PicoClaw workspace md 文件: AGENTS.md (Agent路由), SOUL.md (人格), IDENTITY.md (身份), USER.md (用户偏好), TOOLS.md (工具配置), HEARTBEAT.md (周期任务)

3. service.py generate_config() 自动调用 _inject_workspace_md()
