### PR TITLE
fix: 修复 docker-compose 一键部署的 4 个阻塞问题

### DIFF
--- a/.env.docker
+++ b/.env.docker
@@ -23,16 +23,16 @@ DOCKER_CLICKHOUSE_HTTP_PORT=8123
 REDIS_HOST=redis
 REDIS_PORT=6379
 REDIS_EXPOSE_PORT=16379
-REDIS_PASSWORD=your_redis_password_here
+REDIS_PASSWORD=Stock_datasource666
 REDIS_DB=1
 
 # ============================================
-# Infrastructure - Postgres (for Langfuse)
+# Infrastructure - Postgres (仅 Langfuse 使用，核心应用不需要)
 # ============================================
-POSTGRES_USER=postgres
-POSTGRES_PASSWORD=your_postgres_password_here
-POSTGRES_DB=postgres
-POSTGRES_PORT=15432
+# POSTGRES_USER=postgres
+# POSTGRES_PASSWORD=your_postgres_password_here
+# POSTGRES_DB=postgres
+# POSTGRES_PORT=15432
 
 # ============================================
 # Application Ports
@@ -49,11 +49,11 @@ VITE_API_BASE_URL=
 FRONTEND_TARGET=production
 
 # ============================================
-# Langfuse Configuration (宿主机)
+# Langfuse Configuration (可选，留空则禁用)
 # ============================================
-LANGFUSE_HOST=http://host.docker.internal:3000
-LANGFUSE_PUBLIC_KEY=your_langfuse_public_key_here
-LANGFUSE_SECRET_KEY=your_langfuse_secret_key_here
+LANGFUSE_HOST=
+LANGFUSE_PUBLIC_KEY=
+LANGFUSE_SECRET_KEY=
 
 # ============================================
 # API Keys (required - replace with your keys)

--- a/docker-compose.infra.yml
+++ b/docker-compose.infra.yml
@@ -45,7 +45,7 @@ services:
     networks:
       - stock_network
     healthcheck:
-      test: ["CMD", "redis-cli", "-a", "${REDIS_PASSWORD:-your_redis_password_here}", "ping"]
+      test: ["CMD", "redis-cli", "-a", "${REDIS_PASSWORD:-Stock_datasource666}", "ping"]
       interval: 3s
       timeout: 10s
       retries: 10

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,13 +30,13 @@ services:
       CLICKHOUSE_HOST: ${DOCKER_CLICKHOUSE_HOST:-stock-clickhouse}
       CLICKHOUSE_PORT: ${DOCKER_CLICKHOUSE_PORT:-9000}
       CLICKHOUSE_HTTP_PORT: ${DOCKER_CLICKHOUSE_HTTP_PORT:-8123}
-      CLICKHOUSE_USER: ${CLICKHOUSE_USER:-default}
-      CLICKHOUSE_PASSWORD: ${CLICKHOUSE_PASSWORD:-}
+      CLICKHOUSE_USER: ${CLICKHOUSE_USER:-clickhouse}
+      CLICKHOUSE_PASSWORD: ${CLICKHOUSE_PASSWORD:-clickhouse}
       CLICKHOUSE_DATABASE: ${CLICKHOUSE_DATABASE:-stock_datasource}
       # Redis (compose deployment uses redis over docker network)
       REDIS_HOST: ${DOCKER_REDIS_HOST:-stock-redis}
       REDIS_PORT: ${DOCKER_REDIS_PORT:-6379}
-      REDIS_PASSWORD: ${REDIS_PASSWORD:-}
+      REDIS_PASSWORD: ${REDIS_PASSWORD:-Stock_datasource666}
       REDIS_DB: ${REDIS_DB:-1}
       # Langfuse (默认用宿主机)
       LANGFUSE_HOST: ${LANGFUSE_HOST:-http://host.docker.internal:3000}
@@ -51,7 +51,7 @@ services:
       AUTH_EMAIL_WHITELIST_ENABLED: ${AUTH_EMAIL_WHITELIST_ENABLED:-false}
       AUTH_EMAIL_WHITELIST_FILE: ${AUTH_EMAIL_WHITELIST_FILE:-data/email.txt}
       # MCP auth / usage reconciliation
-      MCP_JWT_PUBLIC_KEY_PATH: /run/secrets/mcp_jwt_public.pem
+      MCP_JWT_PUBLIC_KEY_PATH: ${MCP_JWT_PUBLIC_KEY_PATH:-}
       MCP_USAGE_REPORT_KEY: ${MCP_USAGE_REPORT_KEY:-}
       MCP_INTERNAL_BEARER: ${MCP_INTERNAL_BEARER:-stock-datasource-internal}
       # WeKnora Knowledge Base (optional)
@@ -66,10 +66,11 @@ services:
       - ./.local:/app/.local
       - ./logs:/app/logs
       - ./data:/app/data
-      - ${MCP_JWT_PUBLIC_KEY_HOST_PATH:-/home/jq/code/nps_enhanced/conf/jwt_public.pem}:/run/secrets/mcp_jwt_public.pem:ro
+      # MCP JWT public key mount (optional - only needed if MCP auth is enabled)
+      # To enable: set MCP_JWT_PUBLIC_KEY_HOST_PATH in .env to your public key path
+      # - ${MCP_JWT_PUBLIC_KEY_HOST_PATH}:/run/secrets/mcp_jwt_public.pem:ro
     networks:
       - stock_network
-      - langfuse_default
     command: ["uv", "run", "--no-sync", "python", "-m", "stock_datasource.services.backend_container"]
     healthcheck:
       test: curl -f http://localhost:6666/health && curl -f http://localhost:8001/health || exit 1
@@ -114,13 +115,13 @@ services:
       CLICKHOUSE_HOST: ${DOCKER_CLICKHOUSE_HOST:-stock-clickhouse}
       CLICKHOUSE_PORT: ${DOCKER_CLICKHOUSE_PORT:-9000}
       CLICKHOUSE_HTTP_PORT: ${DOCKER_CLICKHOUSE_HTTP_PORT:-8123}
-      CLICKHOUSE_USER: ${CLICKHOUSE_USER:-default}
-      CLICKHOUSE_PASSWORD: ${CLICKHOUSE_PASSWORD:-}
+      CLICKHOUSE_USER: ${CLICKHOUSE_USER:-clickhouse}
+      CLICKHOUSE_PASSWORD: ${CLICKHOUSE_PASSWORD:-clickhouse}
       CLICKHOUSE_DATABASE: ${CLICKHOUSE_DATABASE:-stock_datasource}
       # Redis (compose deployment uses redis over docker network)
       REDIS_HOST: ${DOCKER_REDIS_HOST:-stock-redis}
       REDIS_PORT: ${DOCKER_REDIS_PORT:-6379}
-      REDIS_PASSWORD: ${REDIS_PASSWORD:-}
+      REDIS_PASSWORD: ${REDIS_PASSWORD:-Stock_datasource666}
       REDIS_DB: ${REDIS_DB:-1}
       # API Keys
       TUSHARE_TOKEN: ${TUSHARE_TOKEN:-}
@@ -130,7 +131,6 @@ services:
       - ./data:/app/data
     networks:
       - stock_network
-      - langfuse_default
     depends_on:
       backend:
         condition: service_healthy
@@ -141,5 +141,3 @@ networks:
   stock_network:
     name: stock_network
     driver: bridge
-  langfuse_default:
-    external: true


### PR DESCRIPTION
## Summary

评估发现当前 docker-compose 配置在新环境无法一键部署，存在 4 个致命问题。本 PR 全部修复：

- **移除 `langfuse_default` 外部网络依赖** — 新环境没有该网络，compose up 第一步就报错退出
- **注释掉 JWT 公钥硬编码挂载** — 默认路径 `/home/jq/code/nps_enhanced/...` 只存在于开发机
- **统一 Redis 密码默认值** — 之前 Redis 服务用 `Stock_datasource666`，健康检查用 `your_redis_password_here`，backend 用空字符串，三处不一致导致认证失败
- **统一 ClickHouse 用户名** — infra.yml 创建 `clickhouse` 用户，但 backend/worker 默认用 `default` 连接

### 修复后部署流程

```bash
cp .env.docker .env
vim .env  # 填入 TUSHARE_TOKEN 和 OPENAI_API_KEY
docker-compose -f docker-compose.yml -f docker-compose.infra.yml up -d
```

> 注：Langfuse 和 WeKnora 为可选服务，不在初始部署范围内，后续从界面按需拉取。

## Test plan

- [ ] 在全新环境（无 `.env`）执行 `docker-compose -f docker-compose.yml -f docker-compose.infra.yml config` 验证无报错
- [ ] 使用 `.env.docker` 作为 `.env` 启动全栈，确认 ClickHouse/Redis/Backend/Frontend 均 healthy
- [ ] 确认不配置 Langfuse/JWT 时服务正常启动不报错

🤖 Generated with [Claude Code](https://claude.com/claude-code)