### PR TITLE
fix: 修复每日同步三个阻塞问题

### DIFF
--- a/src/stock_datasource/modules/datamanage/service.py
+++ b/src/stock_datasource/modules/datamanage/service.py
@@ -432,12 +432,14 @@ class DataManageService:
             for _, row in col_df.iterrows():
                 existing_cols.add((row["table"], row["name"]))
 
-            # Step 2: Build UNION ALL only for validated (table, date_column) pairs
+            # Step 2: Build UNION ALL only for validated (table, date_column) pairs.
+            # Use toString() on max() so that Date, DateTime, and String columns
+            # all produce compatible types (ClickHouse Code 386: no common supertype).
             union_parts = []
             for table_name, date_col in table_date_map.items():
                 if (table_name, date_col) in existing_cols:
                     union_parts.append(
-                        f"SELECT '{table_name}' AS tbl, max({date_col}) AS latest_date FROM {table_name}"
+                        f"SELECT '{table_name}' AS tbl, toString(max({date_col})) AS latest_date FROM {table_name}"
                     )
 
             if not union_parts:

--- a/src/stock_datasource/plugins/tushare_rt_etf_k/plugin.py
+++ b/src/stock_datasource/plugins/tushare_rt_etf_k/plugin.py
@@ -42,3 +42,28 @@ class TuShareRtEtfKPlugin(BasePlugin):
         if not ts_code:
             return pd.DataFrame()
         return extractor.extract(ts_code=ts_code)
+
+    def load_data(self, data: pd.DataFrame) -> dict[str, Any]:
+        """Load realtime ETF K-line into ODS table."""
+        if not self.db:
+            self.logger.error("Database not initialized")
+            return {"status": "failed", "error": "Database not initialized"}
+
+        if data.empty:
+            self.logger.warning("No data to load")
+            return {"status": "no_data", "loaded_records": 0}
+
+        try:
+            table_name = "ods_rt_kline_daily_etf"
+            self.logger.info(f"Loading {len(data)} records into {table_name}")
+            ods_data = self._prepare_data_for_insert(table_name, data)
+            self.db.insert_dataframe(table_name, ods_data)
+            self.logger.info(f"Loaded {len(ods_data)} records into {table_name}")
+            return {
+                "status": "success",
+                "table": table_name,
+                "loaded_records": len(ods_data),
+            }
+        except Exception as e:
+            self.logger.error(f"Failed to load data: {e}")
+            return {"status": "failed", "error": str(e)}

--- a/src/stock_datasource/plugins/tushare_rt_hk_k/plugin.py
+++ b/src/stock_datasource/plugins/tushare_rt_hk_k/plugin.py
@@ -42,3 +42,28 @@ class TuShareRtHkKPlugin(BasePlugin):
         if not ts_code:
             return pd.DataFrame()
         return extractor.extract(ts_code=ts_code)
+
+    def load_data(self, data: pd.DataFrame) -> dict[str, Any]:
+        """Load realtime HK K-line into ODS table."""
+        if not self.db:
+            self.logger.error("Database not initialized")
+            return {"status": "failed", "error": "Database not initialized"}
+
+        if data.empty:
+            self.logger.warning("No data to load")
+            return {"status": "no_data", "loaded_records": 0}
+
+        try:
+            table_name = "ods_rt_kline_daily_hk"
+            self.logger.info(f"Loading {len(data)} records into {table_name}")
+            ods_data = self._prepare_data_for_insert(table_name, data)
+            self.db.insert_dataframe(table_name, ods_data)
+            self.logger.info(f"Loaded {len(ods_data)} records into {table_name}")
+            return {
+                "status": "success",
+                "table": table_name,
+                "loaded_records": len(ods_data),
+            }
+        except Exception as e:
+            self.logger.error(f"Failed to load data: {e}")
+            return {"status": "failed", "error": str(e)}

--- a/src/stock_datasource/plugins/tushare_rt_idx_k/plugin.py
+++ b/src/stock_datasource/plugins/tushare_rt_idx_k/plugin.py
@@ -42,3 +42,28 @@ class TuShareRtIdxKPlugin(BasePlugin):
         if not ts_code:
             return pd.DataFrame()
         return extractor.extract(ts_code=ts_code)
+
+    def load_data(self, data: pd.DataFrame) -> dict[str, Any]:
+        """Load realtime index K-line into ODS table."""
+        if not self.db:
+            self.logger.error("Database not initialized")
+            return {"status": "failed", "error": "Database not initialized"}
+
+        if data.empty:
+            self.logger.warning("No data to load")
+            return {"status": "no_data", "loaded_records": 0}
+
+        try:
+            table_name = "ods_rt_kline_daily_index"
+            self.logger.info(f"Loading {len(data)} records into {table_name}")
+            ods_data = self._prepare_data_for_insert(table_name, data)
+            self.db.insert_dataframe(table_name, ods_data)
+            self.logger.info(f"Loaded {len(ods_data)} records into {table_name}")
+            return {
+                "status": "success",
+                "table": table_name,
+                "loaded_records": len(ods_data),
+            }
+        except Exception as e:
+            self.logger.error(f"Failed to load data: {e}")
+            return {"status": "failed", "error": str(e)}

--- a/src/stock_datasource/plugins/tushare_stock_company/extractor.py
+++ b/src/stock_datasource/plugins/tushare_stock_company/extractor.py
@@ -118,6 +118,11 @@ class StockCompanyExtractor:
         for col in string_cols:
             if col in df.columns:
                 df[col] = df[col].fillna("")
+                # Replace tab/newline characters that would break
+                # ClickHouse TabSeparated format on insert.
+                df[col] = df[col].str.replace("\t", " ", regex=False)
+                df[col] = df[col].str.replace("\n", " ", regex=False)
+                df[col] = df[col].str.replace("\r", " ", regex=False)
 
         return df
 


### PR DESCRIPTION
## 修复内容

修复导致每日同步（18:00）连续两周失败的三个阻塞问题。

### 1. ClickHouse Code 386 — UNION 类型不匹配
**文件**: `modules/datamanage/service.py`

`_batch_get_latest_dates` 对所有表构建 UNION ALL 查询，但部分表的日期列为 `Date`，部分为 `DateTime`（如 `ods_stk_mins`），部分为 `String`（如 `ods_ggt_daily`），ClickHouse 找不到公共超类型。

**修复**: 用 `toString(max(date_col))` 统一转为字符串。

### 2. TabSeparated 解析错误 — 每日必现
**文件**: `plugins/tushare_stock_company/extractor.py`

TuShare 返回的 `main_business`/`business_scope` 字段含未转义制表符，破坏 ClickHouse TabSeparated 格式（Code 27）。

**修复**: 在 `_process_data` 中清洗 `\t` `\n` `\r`。

### 3. 实时插件 load_data 未实现
**文件**: `plugins/tushare_rt_{etf,hk,idx}_k/plugin.py`

三个实时 K 线插件缺少 `load_data()` 抽象方法，导致每次插件发现都报错。

**修复**: 参照 `tushare_rt_k` 补全实现。

## 验证

已在 Docker 容器中验证：
- UNION 查询正常返回结果
- 插件全部加载成功（0 failed）
- 回补 4/30 ~ 5/14 共 8 个交易日数据，7 张核心表全部补齐