### PR TITLE
fix: show chat agent decision traces

### DIFF
--- a/frontend/src/api/chat.ts
+++ b/frontend/src/api/chat.ts
@@ -20,6 +20,8 @@ export interface ChatMessage {
 export interface SendMessageRequest {
   session_id: string
   content: string
+  team_id?: string | null
+  team_name?: string | null
 }
 
 export interface ChatHistoryResponse {
@@ -85,15 +87,21 @@ export interface ErrorEvent {
 
 export interface DebugEvent {
   type: 'debug'
-  debug_type: 'classification' | 'routing' | 'agent_start' | 'agent_end' | 'tool_result' | 'handoff' | 'data_sharing' | 'discussion_argument' | 'decision_summary' | 'preview_signal' | 'arena_error'
+  debug_type: 'classification' | 'routing' | 'agent_start' | 'agent_end' | 'tool_result' | 'handoff' | 'data_sharing' | 'discussion_argument' | 'decision_summary' | 'preview_signal' | 'arena_error' | 'decision_trace'
   agent: string
   timestamp: number
   data: {
-    // classification
+    // classification / decision_trace
     intent?: string
     selected_agent?: string
+    selected_team?: string
     rationale?: string
     available_agents?: string[]
+    stage?: 'orchestrator' | 'team_agent' | 'team_summary' | 'agent'
+    title?: string
+    role?: string
+    key_points?: string[]
+    direction?: 'bullish' | 'bearish' | 'neutral'
     // routing
     from_agent?: string
     to_agent?: string
@@ -189,6 +197,7 @@ export const chatApi = {
   async streamMessagePost(
     sessionId: string,
     content: string,
+    team: { team_id?: string | null; team_name?: string | null } | null,
     onEvent: (event: StreamEvent) => void,
     onError?: (error: Error) => void,
     abortController?: AbortController
@@ -211,7 +220,9 @@ export const chatApi = {
         headers,
         body: JSON.stringify({
           session_id: sessionId,
-          content: content
+          content: content,
+          ...(team?.team_id ? { team_id: team.team_id } : {}),
+          ...(team?.team_name ? { team_name: team.team_name } : {})
         }),
         signal: controller.signal
       })

--- a/frontend/src/stores/chat.ts
+++ b/frontend/src/stores/chat.ts
@@ -140,6 +140,10 @@ export const useChatStore = defineStore('chat', () => {
   } | null>(null)
   const decisionSidebarOpen = ref(false)
 
+  // Selected Agent team for Chat requests
+  const activeTeamId = ref<string | null>(null)
+  const activeTeamName = ref<string | null>(null)
+
   // Preview signal state (instant rule-based, before full LLM synthesis)
   const previewSignal = ref<{
     signal: 'BUY' | 'SELL' | 'HOLD'
@@ -492,7 +496,7 @@ export const useChatStore = defineStore('chat', () => {
       role = 'handoff'
     } else if (debugType === 'data_sharing') {
       role = 'system'
-    } else if (debugType === 'discussion_argument' || debugType === 'decision_summary' || debugType === 'preview_signal' || debugType === 'arena_error') {
+    } else if (debugType === 'discussion_argument' || debugType === 'decision_summary' || debugType === 'preview_signal' || debugType === 'arena_error' || debugType === 'decision_trace') {
       role = 'discussion'
     }
 
@@ -541,6 +545,20 @@ export const useChatStore = defineStore('chat', () => {
       console.log('[Chat] Preview signal received:', previewSignal.value)
     }
 
+    // Special handling for decision_trace team_summary: update decision state
+    if (debugType === 'decision_trace' && data.stage === 'team_summary' && data.signal) {
+      previewSignal.value = null
+      decisionSummary.value = {
+        signal: data.signal as 'BUY' | 'SELL' | 'HOLD' | 'NONE',
+        confidence: data.confidence || 0,
+        bull_count: data.bull_count || 0,
+        bear_count: data.bear_count || 0,
+        neutral_count: data.neutral_count || 0,
+        suggested_action: data.suggested_action || '',
+      }
+      decisionSidebarOpen.value = true
+    }
+
     // Special handling for decision_summary: update decision state (upgrades preview)
     if (debugType === 'decision_summary' && data.signal) {
       // Clear preview signal — the full summary replaces it
@@ -586,6 +604,16 @@ export const useChatStore = defineStore('chat', () => {
     }
   }
 
+  const setActiveTeam = (team: { id?: string; name?: string } | null) => {
+    activeTeamId.value = team?.id || null
+    activeTeamName.value = team?.name || null
+  }
+
+  const clearActiveTeam = () => {
+    activeTeamId.value = null
+    activeTeamName.value = null
+  }
+
   const sendMessage = async (content: string) => {
     if (!sessionId.value) {
       await initSession()
@@ -629,6 +657,9 @@ export const useChatStore = defineStore('chat', () => {
       await chatApi.streamMessagePost(
         sendingSessionId,
         content,
+        activeTeamId.value || activeTeamName.value
+          ? { team_id: activeTeamId.value, team_name: activeTeamName.value }
+          : null,
         (event: StreamEvent) => {
           // SESSION GUARD: If user switched sessions, discard stale events
           if (sessionId.value !== sendingSessionId) {
@@ -899,6 +930,8 @@ export const useChatStore = defineStore('chat', () => {
     decisionSummary,
     decisionSidebarOpen,
     previewSignal,
+    activeTeamId,
+    activeTeamName,
     lastSessionRef,
     // Actions
     initSession,
@@ -909,6 +942,8 @@ export const useChatStore = defineStore('chat', () => {
     updateSessionTitle,
     newConversation,
     clearCurrentConversation,
+    setActiveTeam,
+    clearActiveTeam,
     sendMessage,
     loadHistory,
     clearMessages,

--- a/frontend/src/views/chat/ChatView.vue
+++ b/frontend/src/views/chat/ChatView.vue
@@ -28,10 +28,10 @@ const loadTeams = async () => {
 }
 
 const handleTeamChat = (team: any) => {
-  // Send team name as message to trigger multi-agent collaboration
-  const msg = `请使用"${team.name}"团队模式来协作处理我的下一个问题`
+  chatStore.setActiveTeam(team)
+  chatStore.decisionSidebarOpen = true
   showTeamPanel.value = false
-  handleSend(msg)
+  MessagePlugin.success(`已启用 ${team.name} 团队模式`)
 }
 const showSessionsSidebar = ref(false)
 const editingSessionId = ref('')
@@ -267,7 +267,7 @@ onMounted(async () => {
     MessagePlugin.error('加载历史对话失败，请重新登录后重试')
   }
 
-  // 加载Agent Teams
+  // 加载投研团队
   loadTeams()
 })
 
@@ -569,14 +569,21 @@ const syncUrlToSession = () => {
             @click="showTeamPanel = !showTeamPanel"
           >
             <template #icon><t-icon name="usergroup" /></template>
-            Agent Teams
+            投研团队
           </t-button>
         </div>
 
-        <!-- Agent Teams Panel -->
+        <div v-if="chatStore.activeTeamName" class="active-team-bar">
+          <t-tag theme="primary" variant="light">
+            当前团队：{{ chatStore.activeTeamName }}
+          </t-tag>
+          <t-button size="small" variant="text" @click="chatStore.clearActiveTeam()">退出团队模式</t-button>
+        </div>
+
+        <!-- Research Teams Panel -->
         <div v-if="showTeamPanel" class="workflow-panel">
           <div class="workflow-panel-header">
-            <span>Agent 团队</span>
+            <span>投研团队</span>
             <t-button size="small" variant="text" @click="router.push('/orchestration')">管理团队</t-button>
           </div>
           <div class="workflow-list">
@@ -589,11 +596,11 @@ const syncUrlToSession = () => {
               <t-icon name="usergroup" />
               <div class="workflow-info">
                 <span class="workflow-name">{{ team.name }}</span>
-                <span class="workflow-desc">{{ team.description || '多Agent协作' }}</span>
+                <span class="workflow-desc">{{ team.description || '投研角色协作' }}</span>
               </div>
             </div>
             <div v-if="agentTeams.length === 0" class="workflow-item" style="color:#bbb;justify-content:center">
-              暂无团队，去Agent中心创建
+              暂无团队，去 AI Agent 投研创建
             </div>
           </div>
         </div>
@@ -830,6 +837,13 @@ const syncUrlToSession = () => {
 
 .suggestion-tag:hover {
   opacity: 0.8;
+}
+
+.active-team-bar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 10px;
 }
 
 /* Workflow Panel */

--- a/frontend/src/views/chat/components/AgentDiscussionSidebar.vue
+++ b/frontend/src/views/chat/components/AgentDiscussionSidebar.vue
@@ -63,38 +63,95 @@
       </div>
     </div>
 
-    <!-- Discussion Messages Stream -->
+    <!-- Decision Trace Stream -->
     <div ref="streamContainer" class="discussion-stream">
-      <template v-if="discussionMessages.length > 0">
-        <div
-          v-for="msg in discussionMessages"
-          :key="msg.id"
-          class="stream-message"
-          :class="`direction-${msg.data?.direction || 'neutral'}`"
-        >
-          <div class="msg-header">
-            <span class="msg-role">{{ getAgentLabel(msg.agent) }}</span>
-            <t-tag
-              v-if="msg.data?.direction && msg.data.direction !== 'neutral'"
-              :theme="msg.data.direction === 'bullish' ? 'success' : 'danger'"
-              size="small"
-              variant="light"
-            >
-              {{ msg.data.direction === 'bullish' ? '看多' : '看空' }}
-            </t-tag>
-            <span v-if="msg.data?.confidence" class="msg-confidence">
-              {{ (msg.data.confidence * 100).toFixed(0) }}%
-            </span>
+      <template v-if="hasDecisionEvents">
+        <section v-if="orchestratorTraces.length" class="trace-section">
+          <div class="section-title">调度决策</div>
+          <div v-for="msg in orchestratorTraces" :key="msg.id" class="stream-message decision-orchestrator">
+            <div class="msg-header">
+              <span class="msg-role">{{ msg.data?.title || '调度决策' }}</span>
+              <t-tag v-if="msg.data?.intent" size="small" variant="light">{{ msg.data.intent }}</t-tag>
+            </div>
+            <div class="msg-content">{{ msg.data?.rationale || '正在选择合适的投研路径' }}</div>
+            <div v-if="msg.data?.selected_team || msg.data?.selected_agent" class="trace-meta">
+              <span v-if="msg.data?.selected_team">团队：{{ msg.data.selected_team }}</span>
+              <span v-if="msg.data?.selected_agent">Agent：{{ msg.data.selected_agent }}</span>
+            </div>
           </div>
-          <div class="msg-content">
-            {{ msg.data?.key_point || msg.data?.content || '' }}
+        </section>
+
+        <section v-if="agentTraces.length || discussionMessages.length" class="trace-section">
+          <div class="section-title">Agent 决策流</div>
+          <div
+            v-for="msg in agentTraces"
+            :key="msg.id"
+            class="stream-message"
+            :class="`direction-${msg.data?.direction || 'neutral'}`"
+          >
+            <div class="msg-header">
+              <span class="msg-role">{{ msg.data?.role || getAgentLabel(msg.agent) }}</span>
+              <t-tag
+                v-if="msg.data?.direction && msg.data.direction !== 'neutral'"
+                :theme="msg.data.direction === 'bullish' ? 'success' : 'danger'"
+                size="small"
+                variant="light"
+              >
+                {{ msg.data.direction === 'bullish' ? '看多' : '看空' }}
+              </t-tag>
+              <span v-if="msg.data?.confidence" class="msg-confidence">
+                {{ (msg.data.confidence * 100).toFixed(0) }}%
+              </span>
+            </div>
+            <div class="msg-content">{{ msg.data?.rationale || msg.data?.title || '已进入分析' }}</div>
+            <ul v-if="msg.data?.key_points?.length" class="key-points">
+              <li v-for="point in msg.data.key_points" :key="point">{{ point }}</li>
+            </ul>
           </div>
-        </div>
+          <div
+            v-for="msg in discussionMessages"
+            :key="msg.id"
+            class="stream-message"
+            :class="`direction-${msg.data?.direction || 'neutral'}`"
+          >
+            <div class="msg-header">
+              <span class="msg-role">{{ getAgentLabel(msg.agent) }}</span>
+              <t-tag
+                v-if="msg.data?.direction && msg.data.direction !== 'neutral'"
+                :theme="msg.data.direction === 'bullish' ? 'success' : 'danger'"
+                size="small"
+                variant="light"
+              >
+                {{ msg.data.direction === 'bullish' ? '看多' : '看空' }}
+              </t-tag>
+              <span v-if="msg.data?.confidence" class="msg-confidence">
+                {{ (msg.data.confidence * 100).toFixed(0) }}%
+              </span>
+            </div>
+            <div class="msg-content">
+              {{ msg.data?.key_point || msg.data?.content || '' }}
+            </div>
+          </div>
+        </section>
+
+        <section v-if="summaryTraces.length" class="trace-section">
+          <div class="section-title">最终汇总</div>
+          <div v-for="msg in summaryTraces" :key="msg.id" class="stream-message decision-summary-card">
+            <div class="msg-header">
+              <span class="msg-role">{{ msg.data?.title || '最终决策' }}</span>
+              <t-tag v-if="msg.data?.signal" size="small" theme="primary">{{ msg.data.signal }}</t-tag>
+              <span v-if="msg.data?.confidence" class="msg-confidence">
+                {{ (msg.data.confidence * 100).toFixed(0) }}%
+              </span>
+            </div>
+            <div class="msg-content">{{ msg.data?.suggested_action || msg.data?.rationale || '等待最终汇总' }}</div>
+          </div>
+        </section>
       </template>
       <div v-else class="empty-stream">
         <t-icon name="chat" size="32px" />
         <p>暂无Agent讨论记录</p>
-        <p class="hint">分析股票时，多Agent辩论结果将在此展示</p>
+        <p class="hint">发送消息后，调度与Agent决策逻辑将在此展示</p>
       </div>
     </div>
 
@@ -130,11 +187,31 @@ const emit = defineEmits<{
 const chatStore = useChatStore()
 const streamContainer = ref<HTMLElement | null>(null)
 
+const decisionTraceMessages = computed<DebugMessage[]>(() => {
+  return chatStore.debugMessages.filter(m => m.debugType === 'decision_trace')
+})
+
+const orchestratorTraces = computed<DebugMessage[]>(() => {
+  return decisionTraceMessages.value.filter(m => m.data?.stage === 'orchestrator')
+})
+
+const agentTraces = computed<DebugMessage[]>(() => {
+  return decisionTraceMessages.value.filter(m => m.data?.stage === 'team_agent' || m.data?.stage === 'agent')
+})
+
+const summaryTraces = computed<DebugMessage[]>(() => {
+  return decisionTraceMessages.value.filter(m => m.data?.stage === 'team_summary')
+})
+
 // Get discussion-related messages from the store's live debugMessages
 const discussionMessages = computed<DebugMessage[]>(() => {
   return chatStore.debugMessages.filter(
     m => m.debugType === 'discussion_argument'
   )
+})
+
+const hasDecisionEvents = computed(() => {
+  return decisionTraceMessages.value.length > 0 || discussionMessages.value.length > 0
 })
 
 // Preview signal from store
@@ -172,7 +249,7 @@ function getAgentLabel(agent: string): string {
 }
 
 // Auto-scroll when new messages arrive
-watch(discussionMessages, () => {
+watch([decisionTraceMessages, discussionMessages], () => {
   nextTick(() => {
     if (streamContainer.value) {
       streamContainer.value.scrollTop = streamContainer.value.scrollHeight
@@ -274,6 +351,17 @@ watch(discussionMessages, () => {
   padding: 8px 12px;
 }
 
+.trace-section {
+  margin-bottom: 14px;
+}
+
+.section-title {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--td-text-color-secondary);
+  margin: 4px 0 8px;
+}
+
 .stream-message {
   margin-bottom: 8px;
   padding: 8px 10px;
@@ -286,6 +374,25 @@ watch(discussionMessages, () => {
 .stream-message.direction-bullish { border-left-color: #4caf50; }
 .stream-message.direction-bearish { border-left-color: #f44336; }
 .stream-message.direction-neutral { border-left-color: #9e9e9e; }
+.stream-message.decision-orchestrator { border-left-color: var(--td-brand-color); }
+.stream-message.decision-summary-card { border-left-color: var(--td-warning-color); }
+
+.trace-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 6px;
+  font-size: 11px;
+  color: var(--td-text-color-placeholder);
+}
+
+.key-points {
+  margin: 6px 0 0;
+  padding-left: 16px;
+  color: var(--td-text-color-secondary);
+  font-size: 12px;
+  line-height: 1.5;
+}
 
 .msg-header {
   display: flex;

--- a/src/stock_datasource/agents/config_driven_harness_agent.py
+++ b/src/stock_datasource/agents/config_driven_harness_agent.py
@@ -19,10 +19,7 @@ import time
 from collections.abc import AsyncGenerator, Callable
 from typing import Any
 
-from deepagents import (
-    SubAgentMiddleware,
-    create_deep_agent,
-)
+from deepagents import create_deep_agent
 from langgraph.store.memory import InMemoryStore
 
 from stock_datasource.models.agent_config import AgentConfigResponse, ModelConfig
@@ -162,34 +159,41 @@ class ConfigDrivenHarnessAgent(LangGraphAgent):
         system_prompt = self.get_system_prompt() + self.COMMON_OUTPUT_RULES
         store = get_shared_store()
 
-        # Build middleware
-        middleware = [
-            SubAgentMiddleware(
-                default_model=model,
-                default_tools=tools,
-                subagents=[],
-                general_purpose_agent=True,
-            ),
-        ]
-
         # Create the harness-enabled agent
         self._harness_agent = create_deep_agent(
             model=model,
             tools=tools,
             system_prompt=system_prompt,
-            middleware=middleware,
-            checkpointer=True,
+            checkpointer=False,
             store=store,
             name=self.config.name,
         )
 
         logger.info(
             "ConfigDrivenHarnessAgent '%s' initialized "
-            "(tools=%d, checkpointer=True, store=InMemoryStore)",
+            "(tools=%d, checkpointer=False, store=InMemoryStore)",
             self.config.name,
             len(tools),
         )
         return self._harness_agent
+
+    def _make_agent_decision_trace_event(
+        self, context: dict[str, Any], tool_names: list[str]
+    ) -> dict[str, Any]:
+        """Create a normalized, safe decision trace for this Agent."""
+        return self._make_debug_event(
+            "decision_trace",
+            {
+                "stage": "team_agent" if context.get("team_id") else "agent",
+                "title": self.config.name,
+                "agent": self.config.name,
+                "role": self.config.description,
+                "rationale": "已接收任务并开始基于配置技能分析",
+                "key_points": [f"可用工具 {len(tool_names)} 个"],
+                "direction": "neutral",
+                "confidence": None,
+            },
+        )
 
     async def execute_stream(
         self, task: str, context: dict[str, Any] = None
@@ -257,6 +261,7 @@ class ConfigDrivenHarnessAgent(LangGraphAgent):
                     "parent_agent": context.get("parent_agent"),
                 },
             )
+            yield self._make_agent_decision_trace_event(context, tool_names)
 
             # Build LangGraph config
             config = {

--- a/src/stock_datasource/agents/orchestrator.py
+++ b/src/stock_datasource/agents/orchestrator.py
@@ -29,6 +29,69 @@ class OrchestratorAgent:
             "data": data,
         }
 
+    def _make_team_summary_trace_event(
+        self, context: dict[str, Any], agent_name: str | None
+    ) -> dict[str, Any]:
+        return self._make_debug_event(
+            "decision_trace",
+            {
+                "stage": "team_summary",
+                "title": "团队汇总",
+                "selected_team": context.get("team_name"),
+                "selected_agent": agent_name,
+                "rationale": "已完成团队模式分析，最终结论见回复内容",
+                "suggested_action": "请结合正文分析结论决策",
+            },
+        )
+
+    def _build_local_market_overview_response(self, overview: str) -> str:
+        return (
+            f"{overview}\n\n"
+            "### 可能原因\n"
+            "- 市场下跌通常与风险偏好下降、权重板块走弱、资金观望或外部事件扰动有关。\n"
+            "- 以上原因需要结合当日板块表现、成交额变化、新闻政策和资金流向继续确认。\n"
+            "- 当前为本地数据兜底分析：如需更完整归因，请配置可用 LLM 后由投研 Agent 综合研判。"
+        )
+
+    def _classify_with_rules(
+        self, query: str, agents: list[dict[str, str]]
+    ) -> tuple[str, str | None, str] | None:
+        available_names = {agent["name"] for agent in agents}
+        text = query.lower()
+
+        def pick(*names: str) -> str | None:
+            for name in names:
+                if name in available_names:
+                    return name
+            return None
+
+        if any(keyword in text for keyword in ["今日", "大盘", "市场", "下跌", "上涨", "走势", "原因"]):
+            agent_name = pick("OverviewAgent", "MarketAgent", "板块轮动分析师", "行情分析师")
+            if agent_name:
+                return "market_overview", agent_name, "根据关键词匹配到市场概览分析"
+
+        if any(keyword in text for keyword in ["k线", "技术", "指标", "行情"]):
+            agent_name = pick("MarketAgent", "行情分析师", "技术面专家")
+            if agent_name:
+                return "market_analysis", agent_name, "根据关键词匹配到行情分析"
+
+        if any(keyword in text for keyword in ["财报", "估值", "基本面", "利润", "营收"]):
+            agent_name = pick("ReportAgent", "财报分析师", "价值投资专家")
+            if agent_name:
+                return "financial_report", agent_name, "根据关键词匹配到财报分析"
+
+        if any(keyword in text for keyword in ["新闻", "利好", "利空", "消息"]):
+            agent_name = pick("NewsAnalystAgent", "新闻分析师")
+            if agent_name:
+                return "news_analysis", agent_name, "根据关键词匹配到新闻分析"
+
+        if any(keyword in text for keyword in ["推荐", "筛选", "选股", "低估"]):
+            agent_name = pick("ScreenerAgent", "选股专家")
+            if agent_name:
+                return "stock_screening", agent_name, "根据关键词匹配到选股分析"
+
+        return None
+
     def _parse_json_from_text(self, text: str) -> dict[str, Any]:
         if not text:
             return {}
@@ -145,6 +208,9 @@ class OrchestratorAgent:
             return intent, agent_name, rationale
         except Exception as e:
             logger.warning("[Orchestrator] LLM classify failed: %s", e)
+            rule_result = self._classify_with_rules(query, agents)
+            if rule_result:
+                return rule_result
             return "unknown", None, "意图识别失败"
 
     def _extract_stock_codes(self, query: str) -> list[str]:
@@ -254,6 +320,7 @@ class OrchestratorAgent:
         if stock_codes:
             context["stock_codes"] = stock_codes
 
+        available_agent_names = [agent["name"] for agent in available_agents]
         yield self._make_debug_event(
             "classification",
             {
@@ -261,7 +328,20 @@ class OrchestratorAgent:
                 "selected_agent": agent_name,
                 "rationale": rationale,
                 "stock_codes": stock_codes,
-                "available_agents": [agent["name"] for agent in available_agents],
+                "available_agents": available_agent_names,
+            },
+        )
+        yield self._make_debug_event(
+            "decision_trace",
+            {
+                "stage": "orchestrator",
+                "title": "调度决策",
+                "intent": intent,
+                "selected_agent": agent_name,
+                "selected_team": context.get("team_name"),
+                "rationale": rationale,
+                "stock_codes": stock_codes,
+                "available_agents": available_agent_names,
             },
         )
         yield {
@@ -335,11 +415,36 @@ class OrchestratorAgent:
                     metadata["routed_by"] = "OrchestratorAgent"
                     metadata["available_agents"] = available_agents
                     event["metadata"] = metadata
+                    if context.get("team_id"):
+                        yield self._make_team_summary_trace_event(context, agent.config.name)
                 yield event
         except Exception as e:
             logger.error("Agent %s execution failed: %s", agent_name, e)
-            yield self._error_event(str(e), intent, stock_codes, available_agents)
-            done_seen = False
+            if agent_name == "OverviewAgent" and (
+                "OPENAI_API_KEY" in str(e) or "connect" in str(e).lower()
+            ):
+                from .tools import get_market_overview
+
+                overview = get_market_overview()
+                yield {
+                    "type": "content",
+                    "content": self._build_local_market_overview_response(overview),
+                }
+                yield {
+                    "type": "done",
+                    "metadata": {
+                        "agent": "OverviewAgent",
+                        "intent": intent,
+                        "stock_codes": stock_codes,
+                        "routed_by": "OrchestratorAgent",
+                        "fallback": "local_market_overview",
+                        "available_agents": available_agents,
+                    },
+                }
+                done_seen = True
+            else:
+                yield self._error_event(str(e), intent, stock_codes, available_agents)
+                done_seen = False
 
         if not done_seen:
             yield {

--- a/src/stock_datasource/modules/chat/router.py
+++ b/src/stock_datasource/modules/chat/router.py
@@ -190,10 +190,22 @@ async def stream_message_post(
     current_user: dict = Depends(get_current_user),
 ):
     """Stream a message response using SSE (POST method for longer messages)."""
-    return await _stream_response(request.session_id, request.content, current_user)
+    return await _stream_response(
+        request.session_id,
+        request.content,
+        current_user,
+        team_id=request.team_id,
+        team_name=request.team_name,
+    )
 
 
-async def _stream_response(session_id: str, content: str, current_user: dict):
+async def _stream_response(
+    session_id: str,
+    content: str,
+    current_user: dict,
+    team_id: str | None = None,
+    team_name: str | None = None,
+):
     """Internal function to handle streaming response using OrchestratorAgent."""
     import json
     import traceback
@@ -235,6 +247,10 @@ async def _stream_response(session_id: str, content: str, current_user: dict):
         # SessionMemoryService.get_scoped_history() for even lighter context.
         "history": service.get_session_history(session_id)[-10:],
     }
+    if team_id:
+        context["team_id"] = team_id
+    if team_name:
+        context["team_name"] = team_name
 
     async def generate():
         full_response = ""

--- a/src/stock_datasource/modules/chat/schemas.py
+++ b/src/stock_datasource/modules/chat/schemas.py
@@ -45,6 +45,8 @@ class SendMessageRequest(BaseModel):
 
     session_id: str = Field(..., description="Session ID")
     content: str = Field(..., description="Message content")
+    team_id: str | None = Field(default=None, description="Selected Agent team ID")
+    team_name: str | None = Field(default=None, description="Selected Agent team name")
 
 
 class SendMessageResponse(BaseModel):

--- a/tests/test_chat_decision_trace.py
+++ b/tests/test_chat_decision_trace.py
@@ -1,0 +1,147 @@
+import pytest
+
+from datetime import datetime
+
+from stock_datasource.agents.config_driven_harness_agent import ConfigDrivenHarnessAgent
+from stock_datasource.agents.orchestrator import OrchestratorAgent
+from stock_datasource.models.agent_config import AgentConfigResponse, AgentStatus, ModelConfig
+from stock_datasource.modules.chat.schemas import SendMessageRequest
+
+
+def test_send_message_request_accepts_optional_team_fields():
+    request = SendMessageRequest(
+        session_id="session-1",
+        content="分析贵州茅台",
+        team_id="team-1",
+        team_name="价值投研团队",
+    )
+
+    assert request.team_id == "team-1"
+    assert request.team_name == "价值投研团队"
+
+
+def test_send_message_request_team_fields_are_optional():
+    request = SendMessageRequest(session_id="session-1", content="分析贵州茅台")
+
+    assert request.team_id is None
+    assert request.team_name is None
+
+
+class TraceOnlyOrchestrator(OrchestratorAgent):
+    def _list_available_agents(self):
+        return [
+            {"name": "ReportAgent", "description": "财报分析"},
+            {"name": "MarketAgent", "description": "行情分析"},
+        ]
+
+    async def _classify_with_llm(self, query, context=None):
+        return "financial_report", "ReportAgent", "用户需要财报和估值分析"
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_emits_normalized_decision_trace():
+    orchestrator = TraceOnlyOrchestrator()
+    events = []
+
+    async for event in orchestrator.execute_stream(
+        "分析贵州茅台", {"team_id": "team-1", "team_name": "价值投研团队"}
+    ):
+        events.append(event)
+        if event.get("debug_type") == "decision_trace":
+            break
+
+    trace_events = [event for event in events if event.get("debug_type") == "decision_trace"]
+    assert len(trace_events) == 1
+    trace = trace_events[0]
+    assert trace["agent"] == "OrchestratorAgent"
+    assert trace["data"]["stage"] == "orchestrator"
+    assert trace["data"]["intent"] == "financial_report"
+    assert trace["data"]["selected_agent"] == "ReportAgent"
+    assert trace["data"]["selected_team"] == "价值投研团队"
+    assert trace["data"]["rationale"] == "用户需要财报和估值分析"
+    assert trace["data"]["available_agents"] == ["ReportAgent", "MarketAgent"]
+
+
+def make_agent_config() -> AgentConfigResponse:
+    now = datetime.now()
+    return AgentConfigResponse(
+        id="agent-1",
+        user_id="system",
+        name="财报分析师",
+        description="负责财报和估值判断",
+        avatar="",
+        system_prompt="分析财报",
+        skills=[],
+        user_skills=[],
+        model_config_data=ModelConfig(),
+        tags=[],
+        is_public=True,
+        status=AgentStatus.active,
+        version=1,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+def test_config_driven_agent_builds_normalized_decision_trace_event():
+    agent = ConfigDrivenHarnessAgent(make_agent_config())
+
+    event = agent._make_agent_decision_trace_event(
+        context={"team_id": "team-1"},
+        tool_names=["get_financial_report", "get_stock_valuation"],
+    )
+
+    assert event["type"] == "debug"
+    assert event["debug_type"] == "decision_trace"
+    assert event["agent"] == "财报分析师"
+    assert event["data"]["stage"] == "team_agent"
+    assert event["data"]["title"] == "财报分析师"
+    assert event["data"]["agent"] == "财报分析师"
+    assert event["data"]["role"] == "负责财报和估值判断"
+    assert event["data"]["direction"] == "neutral"
+    assert event["data"]["key_points"] == ["可用工具 2 个"]
+
+
+def test_orchestrator_keyword_fallback_routes_market_decline_query():
+    orchestrator = OrchestratorAgent()
+    agents = [
+        {"name": "OverviewAgent", "description": "市场概览Agent"},
+        {"name": "ChatAgent", "description": "通用对话助手"},
+    ]
+
+    result = orchestrator._classify_with_rules("分析今日下跌的原因", agents)
+
+    assert result == (
+        "market_overview",
+        "OverviewAgent",
+        "根据关键词匹配到市场概览分析",
+    )
+
+
+def test_orchestrator_builds_local_market_overview_response():
+    orchestrator = OrchestratorAgent()
+
+    response = orchestrator._build_local_market_overview_response("## A股市场概况\n- 下跌家数: 3000")
+
+    assert "## A股市场概况" in response
+    assert "下跌家数: 3000" in response
+    assert "可能原因" in response
+
+
+def test_orchestrator_builds_team_summary_decision_trace_event():
+    orchestrator = OrchestratorAgent()
+
+    event = orchestrator._make_team_summary_trace_event(
+        context={"team_id": "team-1", "team_name": "价值投研团队"},
+        agent_name="财报分析师",
+    )
+
+    assert event["type"] == "debug"
+    assert event["debug_type"] == "decision_trace"
+    assert event["agent"] == "OrchestratorAgent"
+    assert event["data"]["stage"] == "team_summary"
+    assert event["data"]["title"] == "团队汇总"
+    assert event["data"]["selected_team"] == "价值投研团队"
+    assert event["data"]["selected_agent"] == "财报分析师"
+    assert event["data"]["rationale"] == "已完成团队模式分析，最终结论见回复内容"
+    assert "signal" not in event["data"]


### PR DESCRIPTION
Expose safe decision trace events in chat and make team selection persist through streamed requests, while fixing the config-driven harness path so real chat requests complete without MCP/checkpointer failures.